### PR TITLE
Make the status bar content optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Based on the <a href="https://github.com/arcticicestudio/nord">Nord</a> color pa
       - [GitHub Repository Clone](#gitHub-repository-clone)
     - [Activation](#activation)
   - [Features](#features)
+  - [Configuration](#configuration)
   - [Plugin Support](#plugin-support)
     - [tmux-prefix-highlight](#tmux-prefix-highlight)
   - [Development](#development)
@@ -79,7 +80,8 @@ tmux source-file `~/.tmux.conf`
 <p align="center"><strong>Fits to many terminal applications based on Nord</strong><br><img src="https://raw.githubusercontent.com/arcticicestudio/nord-tmux/develop/src/assets/scrot-htop.png"/></p>
 
 ## Configuration
-Disable the default status bar content:
+This theme has default status bar content (including the powerline-styled
+background arrows). You can disable the included status bar content:
 ```sh
 set -g @nord_tmux_show_status_content "0"
 ```

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ tmux source-file `~/.tmux.conf`
 
 <p align="center"><strong>Fits to many terminal applications based on Nord</strong><br><img src="https://raw.githubusercontent.com/arcticicestudio/nord-tmux/develop/src/assets/scrot-htop.png"/></p>
 
+## Configuration
+Disable the default status bar content:
+```sh
+set -g @nord_tmux_show_status_content "0"
+```
+
 ## Plugin Support
 ### [tmux-prefix-highlight](https://github.com/tmux-plugins/tmux-prefix-highlight)
 Supports the *prefix*- and `copy-mode` status indicator.

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ set -g @plugin 'arcticicestudio/nord-tmux'
 and press the default key binding `prefix` + <kbd>I</kbd> to fetch the plugin and source it.
 
 #### Manual
-[Download](https://github.com/arcticicestudio/nord-tmux/releases/latest) the latest version of the [`nord.conf`](https://github.com/arcticicestudio/nord-tmux/blob/develop/src/nord.conf) theme file to any directory where `~/.tmux/themes/nord-tmux/nord.conf` is the recommended path.
+[Download](https://github.com/arcticicestudio/nord-tmux/releases/latest) the latest version of the [`*.conf` theme files](https://github.com/arcticicestudio/nord-tmux/tree/develop/src) to any directory where `~/.tmux/themes/nord-tmux` is the recommended path.
 
-Source the downloaded theme by adding it to your `~/.tmux.conf`
+Add the downloaded theme to your `~/.tmux.conf` by sourcing the main file `nord.conf`:
 ```sh
 source-file "~/.tmux/themes/nord-tmux/nord.conf"
 ```

--- a/nord.tmux
+++ b/nord.tmux
@@ -15,16 +15,24 @@
 #   https://tmux.github.io
 NORD_TMUX_COLOR_THEME_FILE=src/nord.conf
 NORD_TMUX_VERSION=0.2.0
+NORD_TMUX_STATUS_CONTENT_FILE="src/nord-status-content.conf"
+NORD_TMUX_STATUS_CONTENT_OPTION="@nord_tmux_show_status_content"
 _current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 __cleanup() {
   unset -v NORD_TMUX_COLOR_THEME_FILE NORD_TMUX_VERSION
+  unset -v NORD_TMUX_STATUS_CONTENT_FILE NORD_TMUX_STATUS_CONTENT_OPTION
   unset -v _current_dir
   unset -f __load __cleanup
 }
 
 __load() {
   tmux source-file "$_current_dir/$NORD_TMUX_COLOR_THEME_FILE"
+
+  local status_content=$(tmux show-option -gqv "$NORD_TMUX_STATUS_CONTENT_OPTION")
+  if [ "$status_content" != "0" ]; then
+    tmux source-file "$_current_dir/$NORD_TMUX_STATUS_CONTENT_FILE"
+  fi;
 }
 
 __load

--- a/src/nord-status-content.conf
+++ b/src/nord-status-content.conf
@@ -1,0 +1,27 @@
+# +++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+# title      Nord tmux                                    +
+# project    nord-tmux                                    +
+# version    0.2.0                                        +
+# repository https://github.com/arcticicestudio/nord-tmux +
+# author     Arctic Ice Studio                            +
+# email      development@arcticicestudio.com              +
+# copyright  Copyright (C) 2017                           +
+# +++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#+----------------+
+#+ Plugin Support +
+#+----------------+
+#+--- tmux-prefix-highlight ---+
+set -g @prefix_highlight_output_prefix "#[fg=brightcyan]#[bg=black]#[nobold]#[noitalics]#[nounderscore]#[bg=brightcyan]#[fg=black]"
+set -g @prefix_highlight_output_suffix ""
+
+#+--------+
+#+ Status +
+#+--------+
+#+--- Bars ---+
+set -g status-left "#[fg=black,bg=blue,bold] #S#[fg=blue,bg=black,nobold,noitalics,nounderscore]"
+set -g status-right "#{prefix_highlight}#[fg=brightblack,bg=black,nobold,noitalics,nounderscore]#[fg=white,bg=brightblack] %Y-%m-%d #[fg=white,bg=brightblack,nobold,noitalics,nounderscore]#[fg=white,bg=brightblack] %H:%M #[fg=cyan,bg=brightblack,nobold,noitalics,nounderscore]#[fg=black,bg=cyan,bold] #H"
+
+#+--- Windows ---+
+set -g window-status-format "#[fg=black,bg=brightblack,nobold,noitalics,nounderscore] #[fg=white,bg=brightblack]#I #[fg=white,bg=brightblack,nobold,noitalics,nounderscore] #[fg=white,bg=brightblack]#W #F #[fg=brightblack,bg=black,nobold,noitalics,nounderscore]"
+set -g window-status-current-format "#[fg=black,bg=cyan,nobold,noitalics,nounderscore] #[fg=black,bg=cyan]#I #[fg=black,bg=cyan,nobold,noitalics,nounderscore] #[fg=black,bg=cyan]#W #F #[fg=cyan,bg=black,nobold,noitalics,nounderscore]"
+set -g window-status-separator ""

--- a/src/nord.conf
+++ b/src/nord.conf
@@ -14,8 +14,6 @@
 set -g @prefix_highlight_fg black
 set -g @prefix_highlight_bg brightcyan
 set -g @prefix_highlight_copy_mode_attr "fg=brightcyan,bg=black,bold"
-set -g @prefix_highlight_output_prefix "#[fg=brightcyan]#[bg=black]#[nobold]#[noitalics]#[nounderscore]#[bg=brightcyan]#[fg=black]"
-set -g @prefix_highlight_output_suffix ""
 
 #+---------+
 #+ Options +
@@ -34,15 +32,6 @@ set -g status-justify left
 set -g status-bg black
 set -g status-fg white
 set -g status-attr none
-
-#+--- Bars ---+
-set -g status-left "#[fg=black,bg=blue,bold] #S#[fg=blue,bg=black,nobold,noitalics,nounderscore]"
-set -g status-right "#{prefix_highlight}#[fg=brightblack,bg=black,nobold,noitalics,nounderscore]#[fg=white,bg=brightblack] %Y-%m-%d #[fg=white,bg=brightblack,nobold,noitalics,nounderscore]#[fg=white,bg=brightblack] %H:%M #[fg=cyan,bg=brightblack,nobold,noitalics,nounderscore]#[fg=black,bg=cyan,bold] #H"
-
-#+--- Windows ---+
-set -g window-status-format "#[fg=black,bg=brightblack,nobold,noitalics,nounderscore] #[fg=white,bg=brightblack]#I #[fg=white,bg=brightblack,nobold,noitalics,nounderscore] #[fg=white,bg=brightblack]#W #F #[fg=brightblack,bg=black,nobold,noitalics,nounderscore]"
-set -g window-status-current-format "#[fg=black,bg=cyan,nobold,noitalics,nounderscore] #[fg=black,bg=cyan]#I #[fg=black,bg=cyan,nobold,noitalics,nounderscore] #[fg=black,bg=cyan]#W #F #[fg=cyan,bg=black,nobold,noitalics,nounderscore]"
-set -g window-status-separator ""
 
 #+-------+
 #+ Panes +


### PR DESCRIPTION
This addresses #7 by making the status bar content optional. The default stays the same. But, by setting a config:
```sh
set -g @nord_tmux_show_status_content "0"
```

You can turn off all status bar content (including the separators, prefixes, and suffixes).