### PR TITLE
adds spacing for ocd

### DIFF
--- a/src/nord-status-content.conf
+++ b/src/nord-status-content.conf
@@ -19,8 +19,8 @@ set -g @prefix_highlight_copy_mode_attr "fg=brightcyan,bg=black,bold"
 #+--------+
 #+--- Bars ---+
 #set -g status-left "#[fg=black,bg=blue,bold] #S#[fg=blue,bg=black,nobold,noitalics,nounderscore]"
-set -g status-left "#[fg=black,bg=blue,bold] #S#[fg=blue,bg=black,nobold,noitalics,nounderscore]"
-set -g status-right "#{prefix_highlight}#[fg=brightblack,bg=black,nobold,noitalics,nounderscore]#[fg=white,bg=brightblack] %Y-%m-%d #[fg=white,bg=brightblack,nobold,noitalics,nounderscore]#[fg=white,bg=brightblack] %H:%M #[fg=cyan,bg=brightblack,nobold,noitalics,nounderscore]#[fg=black,bg=cyan,bold] #H"
+set -g status-left "#[fg=black,bg=blue,bold] #S #[fg=blue,bg=black,nobold,noitalics,nounderscore]"
+set -g status-right "#{prefix_highlight}#[fg=brightblack,bg=black,nobold,noitalics,nounderscore]#[fg=white,bg=brightblack] %Y-%m-%d #[fg=white,bg=brightblack,nobold,noitalics,nounderscore]#[fg=white,bg=brightblack] %H:%M #[fg=cyan,bg=brightblack,nobold,noitalics,nounderscore]#[fg=black,bg=cyan,bold] #H "
 
 #+--- Windows ---+
 set -g window-status-format "#[fg=black,bg=brightblack,nobold,noitalics,nounderscore] #[fg=white,bg=brightblack]#I #[fg=white,bg=brightblack,nobold,noitalics,nounderscore] #[fg=white,bg=brightblack]#W #F #[fg=brightblack,bg=black,nobold,noitalics,nounderscore]"


### PR DESCRIPTION
I tried holding back my ocd, but I couldn't help it. I am not sure if this is intentional, but there are some spaces that appear to be missing in your tmux config. I have added them, but it's up to your discretion as to whether to add them or not. I feel as though it makes it look much better.

before:

![screenshot from 2017-11-19 20-30-07_small](https://user-images.githubusercontent.com/7635158/32998484-6a5ccc88-cd69-11e7-87bd-7b947c977fd1.png)

after:

![screenshot from 2017-11-19 20-30-33_small](https://user-images.githubusercontent.com/7635158/32998486-6e7240a0-cd69-11e7-8ef1-b3b2d69fea2c.png)