### PR TITLE
Remove spaces from status

### DIFF
--- a/src/nord-status-content-no-patched-font.conf
+++ b/src/nord-status-content-no-patched-font.conf
@@ -19,6 +19,6 @@ set -g status-left "#[fg=black,bg=blue,bold] #S "
 set -g status-right "#{prefix_highlight}#[fg=white,bg=brightblack] %Y-%m-%d #[fg=white,bg=brightblack,nobold,noitalics,nounderscore]|#[fg=white,bg=brightblack] %H:%M #[fg=cyan,bg=brightblack,nobold,noitalics,nounderscore] #[fg=black,bg=cyan,bold] #H "
 
 #+--- Windows ---+
-set -g window-status-format " #[fg=white,bg=brightblack]#I #[fg=white,bg=brightblack]#W #F"
-set -g window-status-current-format " #[fg=black,bg=cyan]#I#[fg=black,bg=cyan,nobold,noitalics,nounderscore] #[fg=black,bg=cyan]#W #F"
+set -g window-status-format "#[fg=white,bg=brightblack] #I #[fg=white,bg=brightblack]#W #F "
+set -g window-status-current-format "#[fg=black,bg=cyan] #I#[fg=black,bg=cyan,nobold,noitalics,nounderscore] #[fg=black,bg=cyan]#W #F "
 set -g window-status-separator ""


### PR DESCRIPTION
Without patched font status bar theme is applied with space between
items in window list which looks awkward. This commit removes spaces so
that the theme is looking more consistent when there are no patched
fonts used.