### PR TITLE
Better defaults for pane borders

### DIFF
--- a/src/nord.conf
+++ b/src/nord.conf
@@ -32,12 +32,12 @@ set -g status-attr none
 #+-------+
 #+ Panes +
 #+-------+
-set -g pane-border-bg black
-set -g pane-border-fg black
-set -g pane-active-border-bg black
-set -g pane-active-border-fg brightblack
-set -g display-panes-colour black
-set -g display-panes-active-colour brightblack
+set -g pane-border-fg 'colour4'
+set -g pane-active-border-bg 'colour8'
+set -g pane-active-border-fg 'colour4'
+# set -g pane-active-border-fg brightblack
+# set -g display-panes-colour black
+# set -g display-panes-active-colour brightblack
 
 #+------------+
 #+ Clock Mode +


### PR DESCRIPTION
This change just updates the default colors for pane borders to a different setting. I believe the defaults work fine in iTerm2, but I use the [hyper terminal](https://github.com/zeit/hyper) and with the Nord scheme installed there, the defaults for `pane-border-fg`, `pane-active-border-bg` and `pane-active-border-fg` are invisible. These colors make them visible.