### PR TITLE
Fix colors for tmux 2.9

### DIFF
--- a/src/nord.conf
+++ b/src/nord.conf
@@ -25,17 +25,13 @@ set -g status on
 set -g status-justify left
 
 #+--- Colors ---+
-set -g status-bg black
-set -g status-fg white
-set -g status-attr none
+set -g status-style bg=black,fg=white
 
 #+-------+
 #+ Panes +
 #+-------+
-set -g pane-border-bg black
-set -g pane-border-fg black
-set -g pane-active-border-bg black
-set -g pane-active-border-fg brightblack
+set -g pane-border-style bg=black,fg=black
+set -g pane-active-border-style bg=black,fg=brightblack
 set -g display-panes-colour black
 set -g display-panes-active-colour brightblack
 
@@ -47,7 +43,5 @@ setw -g clock-mode-colour cyan
 #+----------+
 #+ Messages +
 #+---------+
-set -g message-fg cyan
-set -g message-bg brightblack
-set -g message-command-fg cyan
-set -g message-command-bg brightblack
+set -g message-style bg=brightblack,fg=cyan
+set -g message-command-style bg=brightblack,fg=cyan

--- a/src/nord.conf
+++ b/src/nord.conf
@@ -30,8 +30,8 @@ set -g status-style bg=black,fg=white
 #+-------+
 #+ Panes +
 #+-------+
-set -g pane-border-style bg=black,fg=black
-set -g pane-active-border-style bg=black,fg=brightblack
+set -g pane-border-style bg=default,fg=brightblack
+set -g pane-active-border-style bg=default,fg=blue
 set -g display-panes-colour black
 set -g display-panes-active-colour brightblack
 


### PR DESCRIPTION
tmux 2.9 removed the `foo-bg`, `foo-fg`, and `foo-attr` options. Here is the relevant line from the changelog:

>The individual -fg, -bg and -attr options have been removed; they were superseded by -style options in tmux 1.9.

This results in broken styles in many places in nord-tmux. I updated the relevant lines to use the new `foo-style` syntax, and now the theme appears how it did in tmux 2.8.