### PR TITLE
apply new style syntax

### DIFF
--- a/src/nord.conf
+++ b/src/nord.conf
@@ -25,17 +25,13 @@ set -g status on
 set -g status-justify left
 
 #+--- Colors ---+
-set -g status-bg black
-set -g status-fg white
-set -g status-attr none
+set -g mode-style fg=white,bg=black 
 
 #+-------+
 #+ Panes +
 #+-------+
-set -g pane-border-bg black
-set -g pane-border-fg black
-set -g pane-active-border-bg black
-set -g pane-active-border-fg brightblack
+set -g pane-border-style fg=black,bg=black
+set -g pane-active-border-style fg=black,bg=black
 set -g display-panes-colour black
 set -g display-panes-active-colour brightblack
 
@@ -47,7 +43,5 @@ setw -g clock-mode-colour cyan
 #+----------+
 #+ Messages +
 #+---------+
-set -g message-fg cyan
-set -g message-bg brightblack
-set -g message-command-fg cyan
-set -g message-command-bg brightblack
+set -g message-style fg=cyan,bg=brightblack
+set -g message-command-style fg=cyan,bg=brightblack


### PR DESCRIPTION
The current syntax was deprecated in tmux 1.9.  But the tmux upgrade from 2.8 to 2.9 will no longer accept the 'old' syntax.   