### PR TITLE
Migrate nord.tmux file to ZSH shell

### DIFF
--- a/nord.tmux
+++ b/nord.tmux
@@ -1,3 +1,4 @@
+#!/usr/bin/env zsh
 # Copyright (c) 2016-present Sven Greb <development@svengreb.de>
 # This source code is licensed under the MIT license found in the license file.
 
@@ -8,7 +9,7 @@ NORD_TMUX_STATUS_CONTENT_NO_PATCHED_FONT_FILE="src/nord-status-content-no-patche
 NORD_TMUX_STATUS_CONTENT_OPTION="@nord_tmux_show_status_content"
 NORD_TMUX_STATUS_CONTENT_DATE_FORMAT="@nord_tmux_date_format"
 NORD_TMUX_NO_PATCHED_FONT_OPTION="@nord_tmux_no_patched_font"
-_current_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_current_dir="${0:a:h}"
 
 __cleanup() {
   unset -v NORD_TMUX_COLOR_THEME_FILE NORD_TMUX_VERSION
@@ -28,7 +29,7 @@ __load() {
   local no_patched_font=$(tmux show-option -gqv "$NORD_TMUX_NO_PATCHED_FONT_OPTION")
   local date_format=$(tmux show-option -gqv "$NORD_TMUX_STATUS_CONTENT_DATE_FORMAT")
 
-  if [ "$(tmux show-option -gqv "clock-mode-style")" == '12' ]; then
+  if [[ "$(tmux show-option -gqv "clock-mode-style")" == '12' ]]; then
     tmux set-environment -g NORD_TMUX_STATUS_TIME_FORMAT "%I:%M %p"
   else
     tmux set-environment -g NORD_TMUX_STATUS_TIME_FORMAT "%H:%M"


### PR DESCRIPTION
Knowing that most folks run bash as their primary shell, I wanted to create this PR in respect to Apples latest changes to their default shell for new installations. They made the new default shell ZSH and with that PR I've migrated the shell script part of this theme from Bash to ZSH.

Nothing much really, but I thought some might be interested in this.
Not sure where this would live in the theme - separate branch, different file, script that checks for which shell is the primary shell and then switch to that, …

HTH