### PR TITLE
Do not set status-style when disabling the nord statusline

### DIFF
--- a/src/nord-status-content-no-patched-font.conf
+++ b/src/nord-status-content-no-patched-font.conf
@@ -8,6 +8,9 @@
 #+----------------+
 #+ Plugin Support +
 #+----------------+
+#+--- Colors ---+
+set -g status-style bg=black,fg=white
+
 #+--- tmux-prefix-highlight ---+
 set -g @prefix_highlight_copy_mode_attr "fg=black,bg=brightcyan"
 

--- a/src/nord-status-content.conf
+++ b/src/nord-status-content.conf
@@ -8,6 +8,9 @@
 #+----------------+
 #+ Plugin Support +
 #+----------------+
+#+--- Colors ---+
+set -g status-style bg=black,fg=white
+
 #+--- tmux-prefix-highlight ---+
 set -g @prefix_highlight_output_prefix "#[fg=brightcyan]#[bg=black]#[nobold]#[noitalics]#[nounderscore]#[bg=brightcyan]#[fg=black]"
 set -g @prefix_highlight_output_suffix ""

--- a/src/nord.conf
+++ b/src/nord.conf
@@ -24,9 +24,6 @@ set -g status on
 #+--- Layout ---+
 set -g status-justify left
 
-#+--- Colors ---+
-set -g status-style bg=black,fg=white
-
 #+-------+
 #+ Panes +
 #+-------+


### PR DESCRIPTION
This commits fixes the code to not set the `status-style` option when disabling the nord-tmux status-bar.

Usually, when disabling the status-bar, it means a user wants to customize it to his/her liking.
For some reason, overriding this `status-style` option before creating your own bar does not seem to work.
The only way I got things working was to explicitly remove that option from your code.

By setting this option in the `nord-status-content.conf` and `nord-status-content-no-patched-font.conf` files, we ensure it gets only set when a user actually uses the provided status-bars.