### PR TITLE
Fix image URLs after `nord-docs` GitHub flow and `main` branch migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-<p align="center"><a href="https://www.nordtheme.com/ports/tmux" target="_blank"><img src="https://raw.githubusercontent.com/arcticicestudio/nord-docs/develop/assets/images/ports/tmux/repository-hero.svg?sanitize=true"/></a></p>
+<p align="center"><a href="https://www.nordtheme.com/ports/tmux" target="_blank"><img src="https://raw.githubusercontent.com/arcticicestudio/nord-docs/main/assets/images/ports/tmux/repository-hero.svg?sanitize=true"/></a></p>
 
 <p align="center"><a href="https://github.com/arcticicestudio/nord-tmux/releases/latest"><img src="https://img.shields.io/github/release/arcticicestudio/nord-tmux.svg?style=flat-square&label=Release&logo=github&logoColor=eceff4&colorA=4c566a&colorB=88c0d0"/></a> <a href="https://www.nordtheme.com/docs/ports/tmux"><img src="https://img.shields.io/github/release/arcticicestudio/nord-tmux.svg?style=flat-square&label=Docs&colorA=4c566a&colorB=88c0d0&logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiI%2BCiAgICA8cGF0aCBmaWxsPSIjZDhkZWU5IiBkPSJNMTMuNzQ2IDIuODEzYS42Ny42NyAwIDAgMC0uNTU5LS4xMzNMOCAzLjg0OGwtNS4xODgtMS4xOGEuNjY5LjY2OSAwIDAgMC0uNTcuMTMzLjY3Ny42NzcgMCAwIDAtLjI0Mi41MzF2OC4xMzNjLS4wMDguMzIuMjEuNTk4LjUyLjY2OGw1LjMzMiAxLjE5OWguMjk2bDUuMzMyLTEuMmEuNjY4LjY2OCAwIDAgMCAuNTItLjY2N1YzLjMzMmEuNjU5LjY1OSAwIDAgMC0uMjU0LS41MnpNMy4zMzIgNC4xNjhsNCAuODk4djYuNzY2bC00LS44OTh6bTkuMzM2IDYuNzY2bC00IC44OThWNS4wNjZsNC0uODk4em0wIDAiLz4KPC9zdmc%2BCg%3D%3D"/></a></p>
 
@@ -44,7 +44,7 @@ It can be used facing rendering problems with incompatible terminals or fonts.
 set -g @nord_tmux_no_patched_font "1"
 ```
 
-<p align="center"><a href="https://www.nordtheme.com/docs/ports/tmux/configuration#patched-font-characters" target="_blank"><img src="https://raw.githubusercontent.com/arcticicestudio/nord-docs/develop/src/assets/images/ports/tmux/config-no-patched-font.png"/></a></p>
+<p align="center"><a href="https://www.nordtheme.com/docs/ports/tmux/configuration#patched-font-characters" target="_blank"><img src="https://raw.githubusercontent.com/arcticicestudio/nord-docs/main/src/assets/images/ports/tmux/config-no-patched-font.png"/></a></p>
 
 **Optional Status Bar Content** — #7, #10 ⇄ #8, #12 (⊶ 27754979) by [@tsroten][gh-user-tsroten] and [@rgcr][gh-user-rgcr]
 ↠ Added a new theme configuration to [disable the default predefined status bar content][nord-docs-config-default-content], allowing to customize the status content, e.g. adding other plugins or adjust the layout, by setting the `@nord_tmux_show_status_content` variable to `0`:
@@ -53,7 +53,7 @@ set -g @nord_tmux_no_patched_font "1"
 set -g @nord_tmux_show_status_content "0"
 ```
 
-<p align="center"><a href="https://www.nordtheme.com/docs/ports/tmux/configuration#default-status-bar-content" target="_blank"><img src="https://raw.githubusercontent.com/arcticicestudio/nord-docs/develop/src/assets/images/ports/tmux/config-no-status-bar-content.png"/></a></p>
+<p align="center"><a href="https://www.nordtheme.com/docs/ports/tmux/configuration#default-status-bar-content" target="_blank"><img src="https://raw.githubusercontent.com/arcticicestudio/nord-docs/main/src/assets/images/ports/tmux/config-no-status-bar-content.png"/></a></p>
 
 ## Improvements
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><a href="https://www.nordtheme.com/ports/tmux" target="_blank"><img src="https://raw.githubusercontent.com/arcticicestudio/nord-docs/develop/assets/images/ports/tmux/repository-hero.svg?sanitize=true"/></a></p>
+<p align="center"><a href="https://www.nordtheme.com/ports/tmux" target="_blank"><img src="https://raw.githubusercontent.com/arcticicestudio/nord-docs/main/assets/images/ports/tmux/repository-hero.svg?sanitize=true"/></a></p>
 
 <p align="center"><a href="https://github.com/arcticicestudio/nord-tmux/releases/latest" target="_blank"><img src="https://img.shields.io/github/release/arcticicestudio/nord-tmux.svg?style=flat-square&label=Release&logo=github&logoColor=eceff4&colorA=4c566a&colorB=88c0d0"/></a> <a href="https://www.nordtheme.com/docs/ports/tmux"><img src="https://img.shields.io/github/release/arcticicestudio/nord-tmux.svg?style=flat-square&label=Docs&colorA=4c566a&colorB=88c0d0&logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiI%2BCiAgICA8cGF0aCBmaWxsPSIjZDhkZWU5IiBkPSJNMTMuNzQ2IDIuODEzYS42Ny42NyAwIDAgMC0uNTU5LS4xMzNMOCAzLjg0OGwtNS4xODgtMS4xOGEuNjY5LjY2OSAwIDAgMC0uNTcuMTMzLjY3Ny42NzcgMCAwIDAtLjI0Mi41MzF2OC4xMzNjLS4wMDguMzIuMjEuNTk4LjUyLjY2OGw1LjMzMiAxLjE5OWguMjk2bDUuMzMyLTEuMmEuNjY4LjY2OCAwIDAgMCAuNTItLjY2N1YzLjMzMmEuNjU5LjY1OSAwIDAgMC0uMjU0LS41MnpNMy4zMzIgNC4xNjhsNCAuODk4djYuNzY2bC00LS44OTh6bTkuMzM2IDYuNzY2bC00IC44OThWNS4wNjZsNC0uODk4em0wIDAiLz4KPC9zdmc%2BCg%3D%3D"/></a> <a href="https://github.com/arcticicestudio/nord-tmux/blob/develop/CHANGELOG.md" target="_blank"><img src="https://img.shields.io/github/release/arcticicestudio/nord-tmux.svg?style=flat-square&label=Changelog&logo=github&logoColor=eceff4&colorA=4c566a&colorB=88c0d0"/></a></p>
 
@@ -8,7 +8,7 @@
 
 <p align="center">Designed for a fluent and clear workflow based on the <a href="https://www.nordtheme.com" target="_blank">Nord</a> color palette.</p>
 
-<p align="center"><a href="https://www.nordtheme.com/ports/tmux" target="_blank"><img src="https://raw.githubusercontent.com/arcticicestudio/nord-docs/develop/assets/images/ports/tmux/overview.png"/></a></p>
+<p align="center"><a href="https://www.nordtheme.com/ports/tmux" target="_blank"><img src="https://raw.githubusercontent.com/arcticicestudio/nord-docs/main/assets/images/ports/tmux/overview.png"/></a></p>
 
 ## Getting Started
 
@@ -25,7 +25,7 @@ To automatically download and activate Nord tmux, follow the install instruction
 1. add `set -g @plugin "arcticicestudio/nord-tmux"` to your [`tmux.conf`][tmux-man-tmux.conf], by default `.tmux.conf` located in your [home directory][wiki-home_dir]
 2. press the default key binding `prefix` + <kbd>I</kbd> to fetch- and install the plugin
 
-<p align="center"><img src="https://raw.githubusercontent.com/arcticicestudio/nord-docs/develop/assets/images/ports/tmux/installation-tpm.png"/></p>
+<p align="center"><img src="https://raw.githubusercontent.com/arcticicestudio/nord-docs/main/assets/images/ports/tmux/installation-tpm.png"/></p>
 
 See the Nord tmux's documentation for [more installation options][nord-docs-home-install] and how to [set it up manually][nord-docs-home-install#manual].
 Also see [_tpm's_ install instructions][gh-tpm-docs-install-plugins] for more details.
@@ -34,17 +34,17 @@ Also see [_tpm's_ install instructions][gh-tpm-docs-install-plugins] for more de
 
 <div align="center"><p><strong>Your terminal. Your style.</strong></p><p>The unified UI element design provides a clutter-free and fluidly merging appearance.</p></div>
 
-<p align="center"><a href="https://www.nordtheme.com/ports/tmux#intro" target="_blank"><img src="https://raw.githubusercontent.com/arcticicestudio/nord-docs/develop/assets/images/ports/tmux/ui-fluid-appearance-vim.png"/></a></p>
+<p align="center"><a href="https://www.nordtheme.com/ports/tmux#intro" target="_blank"><img src="https://raw.githubusercontent.com/arcticicestudio/nord-docs/main/assets/images/ports/tmux/ui-fluid-appearance-vim.png"/></a></p>
 
-<p align="center"><a href="https://www.nordtheme.com/ports/tmux#introduction" target="_blank"><img src="https://raw.githubusercontent.com/arcticicestudio/nord-docs/develop/assets/images/ports/tmux/ui-fluid-appearance-gotop.png"/></a></p>
+<p align="center"><a href="https://www.nordtheme.com/ports/tmux#introduction" target="_blank"><img src="https://raw.githubusercontent.com/arcticicestudio/nord-docs/main/assets/images/ports/tmux/ui-fluid-appearance-gotop.png"/></a></p>
 
 <div align="center"><p><strong>Uniform design with beautiful UI elements.</strong></p><p>The themed UI elements provide a fluid and unobtrusive transition from the terminal to the tmux status bar.</p></div>
 
-<p align="center"><a href="https://www.nordtheme.com/ports/tmux#ui-elements" target="_blank"><img src="https://raw.githubusercontent.com/arcticicestudio/nord-docs/develop/assets/images/ports/tmux/ui-clock.png"/></a></p>
+<p align="center"><a href="https://www.nordtheme.com/ports/tmux#ui-elements" target="_blank"><img src="https://raw.githubusercontent.com/arcticicestudio/nord-docs/main/assets/images/ports/tmux/ui-clock.png"/></a></p>
 
 <div align="center"><p><strong>Take your favorite plugins with you.</strong></p><p>The theme supports popular plugins for a fluid and unobtrusive user interface transition.</p></div>
 
-<p align="center"><a href="https://www.nordtheme.com/ports/tmux#plugin-support" target="_blank"><img src="https://raw.githubusercontent.com/arcticicestudio/nord-docs/develop/assets/images/ports/tmux/plugins-tmux-prefix-highlight.png"/></a></p>
+<p align="center"><a href="https://www.nordtheme.com/ports/tmux#plugin-support" target="_blank"><img src="https://raw.githubusercontent.com/arcticicestudio/nord-docs/main/assets/images/ports/tmux/plugins-tmux-prefix-highlight.png"/></a></p>
 
 ## Contributing
 
@@ -56,7 +56,7 @@ Please take a moment to read Nord's full [contributing guide][nord-contrib-guide
 
 The guide also includes information about [minimal, complete, and verifiable examples][nord-contrib-guide-mcve] and other ways to contribute to the project like [improving existing issues][nord-contrib-guide-impr-issues] and [giving feedback on issues and pull requests][nord-contrib-guide-feedback].
 
-<p align="center"><img src="https://raw.githubusercontent.com/arcticicestudio/nord-docs/develop/assets/images/nord/repository-footer-separator.svg?sanitize=true" /></p>
+<p align="center"><img src="https://raw.githubusercontent.com/arcticicestudio/nord-docs/main/assets/images/nord/repository-footer-separator.svg?sanitize=true" /></p>
 
 <p align="center">Copyright &copy; 2017-present <a href="https://www.arcticicestudio.com" target="_blank">Arctic Ice Studio</a> and <a href="https://www.svengreb.de" target="_blank">Sven Greb</a></p>
 


### PR DESCRIPTION
Fixes #72 