### PR TITLE
Configurable time and date visibility

### DIFF
--- a/nord.tmux
+++ b/nord.tmux
@@ -15,6 +15,8 @@ NORD_TMUX_STATUS_CONTENT_NO_PATCHED_FONT_FILE="src/nord-status-content-no-patche
 NORD_TMUX_STATUS_CONTENT_OPTION="@nord_tmux_show_status_content"
 NORD_TMUX_STATUS_CONTENT_DATE_FORMAT="@nord_tmux_date_format"
 NORD_TMUX_NO_PATCHED_FONT_OPTION="@nord_tmux_no_patched_font"
+NORD_TMUX_SHOW_DATE="@nord_tmux_show_date"
+NORD_TMUX_SHOW_TIME="@nord_tmux_show_time"
 _current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 __cleanup() {
@@ -22,6 +24,7 @@ __cleanup() {
   unset -v NORD_TMUX_STATUS_CONTENT_FILE NORD_TMUX_STATUS_CONTENT_NO_PATCHED_FONT_FILE
   unset -v NORD_TMUX_STATUS_CONTENT_OPTION NORD_TMUX_NO_PATCHED_FONT_OPTION
   unset -v NORD_TMUX_STATUS_CONTENT_DATE_FORMAT
+  unset -v NORD_TMUX_SHOW_DATE NORD_TMUX_SHOW_TIME
   unset -v _current_dir
   unset -f __load __cleanup
   tmux set-environment -gu NORD_TMUX_STATUS_TIME_FORMAT
@@ -34,6 +37,8 @@ __load() {
   local status_content=$(tmux show-option -gqv "$NORD_TMUX_STATUS_CONTENT_OPTION")
   local no_patched_font=$(tmux show-option -gqv "$NORD_TMUX_NO_PATCHED_FONT_OPTION")
   local date_format=$(tmux show-option -gqv "$NORD_TMUX_STATUS_CONTENT_DATE_FORMAT")
+  local show_date=$(tmux show-option -gqv "$NORD_TMUX_SHOW_DATE")
+  local show_time=$(tmux show-option -gqv "$NORD_TMUX_SHOW_TIME")
 
   if [ "$(tmux show-option -gqv "clock-mode-style")" == '12' ]; then
     tmux set-environment -g NORD_TMUX_STATUS_TIME_FORMAT "%I:%M %p"
@@ -41,11 +46,9 @@ __load() {
     tmux set-environment -g NORD_TMUX_STATUS_TIME_FORMAT "%H:%M"
   fi
 
-  if [ -z "$date_format" ]; then
-    tmux set-environment -g NORD_TMUX_STATUS_DATE_FORMAT "%Y-%m-%d"
-  else
-    tmux set-environment -g NORD_TMUX_STATUS_DATE_FORMAT "$date_format"
-  fi
+  tmux set-environment -g NORD_TMUX_STATUS_DATE_FORMAT ${date_format:-%Y-%m-%d}
+  tmux set-environment -g NORD_TMUX_SHOW_DATE ${show_date:-1}
+  tmux set-environment -g NORD_TMUX_SHOW_TIME ${show_time:-1}
 
   if [ "$status_content" != "0" ]; then
     if [ "$no_patched_font" != "1" ]; then

--- a/src/nord-status-content-no-patched-font.conf
+++ b/src/nord-status-content-no-patched-font.conf
@@ -16,7 +16,7 @@ set -g @prefix_highlight_copy_mode_attr "fg=black,bg=brightcyan"
 #+--------+
 #+--- Bars ---+
 set -g status-left "#[fg=black,bg=blue,bold] #S "
-set -g status-right "#{prefix_highlight}#[fg=white,bg=brightblack] ${NORD_TMUX_STATUS_DATE_FORMAT} #[fg=white,bg=brightblack,nobold,noitalics,nounderscore]|#[fg=white,bg=brightblack] ${NORD_TMUX_STATUS_TIME_FORMAT} #[fg=cyan,bg=brightblack,nobold,noitalics,nounderscore] #[fg=black,bg=cyan,bold] #H "
+set -g status-right "#{prefix_highlight}#{?#{NORD_TMUX_SHOW_DATE},#[fg=white]#[bg=brightblack] ${NORD_TMUX_STATUS_DATE_FORMAT},}#{?#{&&:#{NORD_TMUX_SHOW_DATE},#{NORD_TMUX_SHOW_TIME}}, #[fg=white]#[bg=brightblack]#[nobold]#[noitalics]#[nounderscore]|,}#{?#{NORD_TMUX_SHOW_TIME},#[fg=white]#[bg=brightblack] ${NORD_TMUX_STATUS_TIME_FORMAT},}#[fg=cyan,bg=brightblack,nobold,noitalics,nounderscore] #[fg=black,bg=cyan,bold] #H "
 
 #+--- Windows ---+
 set -g window-status-format " #[fg=white,bg=brightblack]#I #[fg=white,bg=brightblack]#W #F"

--- a/src/nord-status-content-no-patched-font.conf
+++ b/src/nord-status-content-no-patched-font.conf
@@ -16,7 +16,7 @@ set -g @prefix_highlight_copy_mode_attr "fg=black,bg=brightcyan"
 #+--------+
 #+--- Bars ---+
 set -g status-left "#[fg=black,bg=blue,bold] #S "
-set -g status-right "#{prefix_highlight}#{?#{NORD_TMUX_SHOW_DATE},#[fg=white]#[bg=brightblack] ${NORD_TMUX_STATUS_DATE_FORMAT},}#{?#{&&:#{NORD_TMUX_SHOW_DATE},#{NORD_TMUX_SHOW_TIME}}, #[fg=white]#[bg=brightblack]#[nobold]#[noitalics]#[nounderscore]|,}#{?#{NORD_TMUX_SHOW_TIME},#[fg=white]#[bg=brightblack] ${NORD_TMUX_STATUS_TIME_FORMAT},}#[fg=cyan,bg=brightblack,nobold,noitalics,nounderscore] #[fg=black,bg=cyan,bold] #H "
+set -g status-right "#{prefix_highlight}#{?#{NORD_TMUX_SHOW_DATE},#[fg=white]#[bg=brightblack] ${NORD_TMUX_STATUS_DATE_FORMAT} ,}#{?#{&&:#{NORD_TMUX_SHOW_DATE},#{NORD_TMUX_SHOW_TIME}},#[fg=white]#[bg=brightblack]#[nobold]#[noitalics]#[nounderscore]|,}#{?#{NORD_TMUX_SHOW_TIME},#[fg=white]#[bg=brightblack] ${NORD_TMUX_STATUS_TIME_FORMAT} ,}#[fg=black,bg=cyan,bold] #H "
 
 #+--- Windows ---+
 set -g window-status-format " #[fg=white,bg=brightblack]#I #[fg=white,bg=brightblack]#W #F"

--- a/src/nord-status-content.conf
+++ b/src/nord-status-content.conf
@@ -18,7 +18,7 @@ set -g @prefix_highlight_copy_mode_attr "fg=brightcyan,bg=black,bold"
 #+--------+
 #+--- Bars ---+
 set -g status-left "#[fg=black,bg=blue,bold] #S #[fg=blue,bg=black,nobold,noitalics,nounderscore]"
-set -g status-right "#{prefix_highlight}#[fg=brightblack,bg=black,nobold,noitalics,nounderscore]#[fg=white,bg=brightblack] ${NORD_TMUX_STATUS_DATE_FORMAT} #[fg=white,bg=brightblack,nobold,noitalics,nounderscore]#[fg=white,bg=brightblack] ${NORD_TMUX_STATUS_TIME_FORMAT} #[fg=cyan,bg=brightblack,nobold,noitalics,nounderscore]#[fg=black,bg=cyan,bold] #H "
+set -g status-right "#{prefix_highlight}#{?#{||:#{NORD_TMUX_SHOW_DATE},#{NORD_TMUX_SHOW_TIME}},#[fg=brightblack]#[bg=black]#[nobold]#[noitalics]#[nounderscore],}#{?#{NORD_TMUX_SHOW_DATE},#[fg=white]#[bg=brightblack] ${NORD_TMUX_STATUS_DATE_FORMAT} ,}#[fg=#{?#{NORD_TMUX_SHOW_DATE},white,brightblack},bg=#{?NORD_TMUX_SHOW_DATE,brightblack,black},nobold,noitalics,nounderscore]#{?#{&&:#{NORD_TMUX_SHOW_DATE},#{NORD_TMUX_SHOW_TIME}},,}#{?#{NORD_TMUX_SHOW_TIME},#[fg=white]#[bg=brightblack] ${NORD_TMUX_STATUS_TIME_FORMAT} ,}#[fg=cyan,bg=#{?#{||:#{NORD_TMUX_SHOW_DATE},#{NORD_TMUX_SHOW_TIME}},brightblack,default},nobold,noitalics,nounderscore]#[fg=black,bg=cyan,bold] #H "
 
 #+--- Windows ---+
 set -g window-status-format "#[fg=black,bg=brightblack,nobold,noitalics,nounderscore] #[fg=white,bg=brightblack]#I #[fg=white,bg=brightblack,nobold,noitalics,nounderscore] #[fg=white,bg=brightblack]#W #F #[fg=brightblack,bg=black,nobold,noitalics,nounderscore]"


### PR DESCRIPTION
Hello,

I use your theme everywhere I can : i3, JetBrains and tmux. So it's time to contribute to one of the configuration. :slightly_smiling_face: 

As I put my date and time in my i3 bar, I don't want to have it in my tmux.

I propose this patch to add some configuration in order to only have date, time or both displayed and keep a clean look. Both is the default to get some backward compatibility.

Here are some screen for the different possible configuration.

| variation | patched font enabled | non patched font |
|-------------|------------------------------|------------------------|
| time and date | ![both enabled with patched font](https://user-images.githubusercontent.com/457663/210010003-35a52696-7872-414e-917a-3cb3246888ec.png) | ![both enabled without patched font](https://user-images.githubusercontent.com/457663/210010662-af94a4a4-9741-436f-b33a-1274aa934e5b.png) |
| time only | ![time only with patched font](https://user-images.githubusercontent.com/457663/210010052-1ceca41c-20e4-41f7-8e38-927e161a82b4.png) | ![time only without patched font](https://user-images.githubusercontent.com/457663/210010723-08d49f2d-ef7d-4cb9-bfd8-fcd909e50a09.png) |
| date only | ![date only with patched font](https://user-images.githubusercontent.com/457663/210010109-347c1f5e-8835-4753-9554-96bdd5aa9e1a.png) | ![date only without patched font](https://user-images.githubusercontent.com/457663/210010791-969d164a-093a-4c08-bac9-aab1054e7d34.png) |
| none | ![none with patched font](https://user-images.githubusercontent.com/457663/210010159-c3ad6bbc-1f5b-4d46-a80d-31e9b0ffedc0.png) | ![none without patched font](https://user-images.githubusercontent.com/457663/210010907-4cf82cdc-d03a-408c-ae0d-3c438f8f6caa.png) |

Colors may look darker because my background is dark and my terminal background is transparent.

I refactored a bit for the `NORD_TMUX_STATUS_DATE_FORMAT` to prevent too many deep `if`s and set my two new variables the same way.

I made an attempt on my machine to get a neater `status-right` value but it didn't worked so I ended up doing like so but if anyone has better to propose, I'll be happy to make some changes. As you can see I was forced to explode the different `#[fg=...,bg=...]` into multiple `#[fg=...]#[bg=...]...` otherwise it didn't work.

A last thing that I didn't understood is that you put `tmux set-environment -gu NORD_TMUX_STATUS_TIME` and same for date and everything works as expected, we can change the option, reload configuration and changes is made.
I tried to add my two new variables but in this case they are always considered as `0` so nothing is displayed. Again, if anyone can give me the answer, I'll be happy to learn.

Thank you!