### PR TITLE
Fix name of plugin to be used for TPM

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@ Thanks to existing plugin managers for tmux, Nord tmux can be installed for all 
 
 To automatically download and activate Nord tmux, follow the install instructions for [tpm][gh-tmux-plugins/tpm] and
 
-1. add `set -g @plugin "nordtheme/tmux"` to your [`tmux.conf`][tmux-man-tmux.conf], by default `.tmux.conf` located in your [home directory][wiki-home_dir]
+1. add `set -g @plugin "arcticicestudio/nord-tmux"` to your [`tmux.conf`][tmux-man-tmux.conf], by default `.tmux.conf` located in your [home directory][wiki-home_dir]
 2. press the default key binding `prefix` + <kbd>I</kbd> to fetch- and install the plugin
 
 <p align="center">


### PR DESCRIPTION
The plugin name stated in the README.md of `nordtheme/tmux` does not work, but `arcticicestudio/nord-tmux` as shown in the screenshot of the second step, does work.