### PR TITLE
Fixed incorrect tab formatting when 'window_activity_flag' is set on window

### DIFF
--- a/src/nord-status-content-no-patched-font.conf
+++ b/src/nord-status-content-no-patched-font.conf
@@ -15,6 +15,9 @@ set -g status-left "#[fg=black,bg=blue,bold] #S "
 set -g status-right "#{prefix_highlight}#[fg=white,bg=brightblack] ${NORD_TMUX_STATUS_DATE_FORMAT} #[fg=white,bg=brightblack,nobold,noitalics,nounderscore]|#[fg=white,bg=brightblack] ${NORD_TMUX_STATUS_TIME_FORMAT} #[fg=cyan,bg=brightblack,nobold,noitalics,nounderscore] #[fg=black,bg=cyan,bold] #H "
 
 #+--- Windows ---+
-set -g window-status-format " #[fg=white,bg=brightblack]#I #[fg=white,bg=brightblack]#W #F"
+%hidden NORMAL_FORMAT=" #[fg=white,bg=brightblack]#I #[fg=white,bg=brightblack]#W #F"
+%hidden ACTIVITY_FORMAT=" #[fg=white,bg=brightblack,bold]#I #[fg=white,bg=brightblack,bold]#W #F"
+set -g window-status-format "#{?window_activity_flag,#{E:ACTIVITY_FORMAT},#{E:NORMAL_FORMAT}}"
 set -g window-status-current-format " #[fg=black,bg=cyan]#I#[fg=black,bg=cyan,nobold,noitalics,nounderscore] #[fg=black,bg=cyan]#W #F"
+set -g window-status-activity-style ""
 set -g window-status-separator ""

--- a/src/nord-status-content.conf
+++ b/src/nord-status-content.conf
@@ -17,6 +17,9 @@ set -g status-left "#[fg=black,bg=blue,bold] #S #[fg=blue,bg=black,nobold,noital
 set -g status-right "#{prefix_highlight}#[fg=brightblack,bg=black,nobold,noitalics,nounderscore]#[fg=white,bg=brightblack] ${NORD_TMUX_STATUS_DATE_FORMAT} #[fg=white,bg=brightblack,nobold,noitalics,nounderscore]#[fg=white,bg=brightblack] ${NORD_TMUX_STATUS_TIME_FORMAT} #[fg=cyan,bg=brightblack,nobold,noitalics,nounderscore]#[fg=black,bg=cyan,bold] #H "
 
 #+--- Windows ---+
-set -g window-status-format "#[fg=black,bg=brightblack,nobold,noitalics,nounderscore] #[fg=white,bg=brightblack]#I #[fg=white,bg=brightblack,nobold,noitalics,nounderscore] #[fg=white,bg=brightblack]#W #F #[fg=brightblack,bg=black,nobold,noitalics,nounderscore]"
+%hidden NORMAL_FORMAT="#[fg=black,bg=brightblack,nobold,noitalics,nounderscore] #[fg=white,bg=brightblack]#I #[fg=white,bg=brightblack,nobold,noitalics,nounderscore] #[fg=white,bg=brightblack]#W #F #[fg=brightblack,bg=black,nobold,noitalics,nounderscore]"
+%hidden ACTIVITY_FORMAT="#[fg=black,bg=brightblack,nobold,noitalics,nounderscore] #[fg=white,bg=brightblack,bold]#I #[fg=white,bg=brightblack,bold,noitalics,nounderscore] #[fg=white,bg=brightblack,bold]#W #F #[fg=brightblack,bg=black,nobold,noitalics,nounderscore]"
+set -g window-status-format "#{?window_activity_flag,#{E:ACTIVITY_FORMAT},#{E:NORMAL_FORMAT}}"
 set -g window-status-current-format "#[fg=black,bg=cyan,nobold,noitalics,nounderscore] #[fg=black,bg=cyan]#I #[fg=black,bg=cyan,nobold,noitalics,nounderscore] #[fg=black,bg=cyan]#W #F #[fg=cyan,bg=black,nobold,noitalics,nounderscore]"
+set -g window-status-activity-style ""
 set -g window-status-separator ""


### PR DESCRIPTION
If there is a process running on another tab, currently the default behavior in tmux is to swap fg and bg colors, causing tabs to look like this:

![Screenshot from 2024-04-06 14-24-19](https://github.com/nordtheme/tmux/assets/5098329/9fdeb11c-6810-4ebe-8760-e7ad85f7d378)
_The second tab has activity and has flipped colors._

One workaround is to set `window-status-activity-style` to an empty string to disable the color inversion. This is safe because `window-status-activity-style` is ignored when `window-status-format` is set.

![Screenshot from 2024-04-06 14-31-29](https://github.com/nordtheme/tmux/assets/5098329/26bc10d1-a9e8-4ee0-b706-7e3d907c2022)
_The second tab has activity but no visual signifier._

To improve on this, we can make use of conditionals to bold activity text.

![Screenshot from 2024-04-07 05-50-08](https://github.com/nordtheme/tmux/assets/5098329/8724146e-b315-41c8-bb09-07ab582f3b6c)
_The second tab has activity and is bolded._

The third figure is the fix and functionality that this pull request provides.