### PR TITLE
Fix `message-style` for newer tmux versions

### DIFF
--- a/src/nord.conf
+++ b/src/nord.conf
@@ -39,5 +39,5 @@ setw -g clock-mode-colour cyan
 #+----------+
 #+ Messages +
 #+---------+
-set -g message-style bg=brightblack,fg=cyan
+set -g message-style bg=brightblack,fg=cyan,fill=brightblack
 set -g message-command-style bg=brightblack,fg=cyan


### PR DESCRIPTION
If you are using tmux 3.7 or newer you'll probably have encountered this behavior:

<video src="https://github.com/user-attachments/assets/278025b1-1163-42bd-9328-fd388e810f4f" controls></video>



This is probably related to the changes made in this commit https://github.com/tmux/tmux/commit/19f3fb13.

To fix this and get the old look back, this new `fill` argument needs to be applied.